### PR TITLE
Fix: Python environment and Makefile process management improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,8 +196,10 @@ start-backend:
 	fi
 	$(call check_port,$(BACKEND_PORT))
 	@cd $(BACKEND_DIR) && \
+	{ \
 		poetry run uvicorn app.main:app --reload --host 0.0.0.0 --port $(BACKEND_PORT) & \
-		echo $$! > ../$(PROCESS_DIR)/backend.pid
+		echo $$! > ../$(PROCESS_DIR)/backend.pid; \
+	}
 	@echo "✅ Backend server started"
 	@echo "   📍 URL: http://localhost:$(BACKEND_PORT)"
 	@echo "   📍 API Docs: http://localhost:$(BACKEND_PORT)/docs"


### PR DESCRIPTION
## Problem
The backend development environment had two main issues:
1. **Python Environment**: Poetry virtual environment was broken due to Python version mismatch after Homebrew updates (3.13.1 → 3.13.7)
2. **Process Management**: `make stop` command couldn't stop backend processes because PID files weren't being created properly

## Root Cause
- Poetry's virtual environment was looking for Python 3.13.1 that no longer existed after Homebrew updated to 3.13.7
- The Makefile's `start-backend` command had incorrect shell syntax that prevented PID capture
- The `asyncpg` dependency has compatibility issues with Python 3.13

## Solution
### Python Environment
- Reinstalled Poetry via Homebrew to fix broken installation
- Recreated virtual environment using Python 3.12.6 (fully compatible with all dependencies)
- Successfully installed all project dependencies including `asyncpg`

### Makefile Improvements
- Fixed `start-backend` command to properly capture and save process PID
- Used shell command grouping to ensure PID is saved after backgrounding uvicorn
- Created missing `backend/.env` file from `.env.example` template

## Testing
- ✅ Backend starts successfully with `make start-backend`
- ✅ Backend stops properly with `make stop`
- ✅ API accessible at http://localhost:8000
- ✅ Interactive docs available at http://localhost:8000/docs
- ✅ All dependencies installed and working

## Files Changed
- `Makefile`: Fixed process PID capture in start-backend command
- `backend/.env`: Created from template (not committed, in .gitignore)

This ensures reliable development environment setup and process management for all team members.